### PR TITLE
Keep phone screen enabled when proximity sensor is triggered (Android-only)

### DIFF
--- a/android/src/main/java/com/cindyu/all_sensors/AllSensorsPlugin.java
+++ b/android/src/main/java/com/cindyu/all_sensors/AllSensorsPlugin.java
@@ -15,6 +15,7 @@ import io.flutter.embedding.android.FlutterActivity;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
+import io.flutter.plugin.common.MethodChannel;
 
 import static android.content.Context.POWER_SERVICE;
 
@@ -26,12 +27,13 @@ public class AllSensorsPlugin implements FlutterPlugin {
   private static final String GYROSCOPE_CHANNEL_NAME = "cindyu.com/all_sensors/gyroscope";
   private static final String USER_ACCELEROMETER_CHANNEL_NAME = "cindyu.com/all_sensors/user_accel";
   private static final String PROXIMITY_CHANNELNAME = "cindyu.com/all_sensors/proximity";
-
+  private static final String METHOD_CHANNELNAME = "cindyu.com/all_sensors";
 
   private EventChannel accelerometerChannel;
   private EventChannel userAccelChannel;
   private EventChannel gyroscopeChannel;
   private EventChannel proximityChannel;
+  private MethodChannel methodChannel;
 
 
   /** Plugin registration. */
@@ -43,7 +45,6 @@ public class AllSensorsPlugin implements FlutterPlugin {
   }
 
   private void setupEventChannels(Context context, BinaryMessenger messenger) {
-
     accelerometerChannel = new EventChannel(messenger, ACCELEROMETER_CHANNEL_NAME);
     accelerometerChannel.setStreamHandler(
             new StreamHandlerImpl((SensorManager)context.getSystemService(context.SENSOR_SERVICE), Sensor.TYPE_ACCELEROMETER));
@@ -57,9 +58,12 @@ public class AllSensorsPlugin implements FlutterPlugin {
             new StreamHandlerImpl((SensorManager)context.getSystemService(context.SENSOR_SERVICE), Sensor.TYPE_GYROSCOPE));
 
     proximityChannel = new EventChannel(messenger, PROXIMITY_CHANNELNAME);
-    proximityChannel.setStreamHandler(
-            new StreamHandlerImpl((SensorManager)context.getSystemService(context.SENSOR_SERVICE), Sensor.TYPE_PROXIMITY,
-                    (PowerManager) context.getSystemService(POWER_SERVICE)));
+    StreamHandlerImpl proximityStreamHandler = new StreamHandlerImpl((SensorManager)context.getSystemService(context.SENSOR_SERVICE), Sensor.TYPE_PROXIMITY,
+            (PowerManager) context.getSystemService(POWER_SERVICE));
+    proximityChannel.setStreamHandler(proximityStreamHandler);
+
+    methodChannel = new MethodChannel(messenger, METHOD_CHANNELNAME);
+    methodChannel.setMethodCallHandler(new MethodCallHandlerImpl(proximityStreamHandler));
   }
 
   @Override

--- a/android/src/main/java/com/cindyu/all_sensors/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/cindyu/all_sensors/MethodCallHandlerImpl.java
@@ -1,0 +1,26 @@
+package com.cindyu.all_sensors;
+
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
+import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
+import io.flutter.plugin.common.MethodChannel.Result;
+
+import com.cindyu.all_sensors.StreamHandlerImpl;
+
+public class MethodCallHandlerImpl implements MethodCallHandler {
+  private final StreamHandlerImpl proximityStreamHandler;
+
+  public MethodCallHandlerImpl(StreamHandlerImpl proximityStreamHandler) {
+    this.proximityStreamHandler = proximityStreamHandler;
+  }
+
+  @Override
+  public void onMethodCall(MethodCall call, Result result) {
+    if (call.method.equals("toggleScreenOnProximityChanged")) {
+      Boolean enabled = (Boolean) call.argument("enabled");
+      this.proximityStreamHandler.setToggleScreenOnProximityChanged(enabled);
+    } else {
+      result.notImplemented();
+    }
+  }
+}

--- a/lib/all_sensors.dart
+++ b/lib/all_sensors.dart
@@ -12,6 +12,9 @@ const EventChannel _gyroscopeEventChannel = EventChannel('cindyu.com/all_sensors
 
 const EventChannel _proximityEventChannel = EventChannel('cindyu.com/all_sensors/proximity');
 
+const MethodChannel _methodChannel = MethodChannel('cindyu.com/all_sensors');
+
+
 class AccelerometerEvent {
   /// Acceleration force along the x axis (including gravity) measured in m/s^2.
   final double x;
@@ -134,4 +137,12 @@ Stream<ProximityEvent>? get proximityEvents {
       .map((dynamic event) => _listToProximityEvent(event.cast<double>()));
 
   return _proximityEvents;
+}
+
+/// Android only. Select if the screen is automatically turned on/off when the proximity changes.
+Future<void> toggleScreenOnProximityChanged(bool enabled) {
+  return _methodChannel.invokeMethod<void>(
+    'toggleScreenOnProximityChanged',
+    <String, dynamic>{'enabled': enabled},
+  );
 }


### PR DESCRIPTION
Added a toggleScreenOnProximityChanged function that keeps the phone screen enabled when the proximity sensor is triggered.
Unfortunately, this is only possible on Android but I wanted to add this functionality anyways as it was discussed about in #6.